### PR TITLE
Fixed bugs when saving a duplicate, changed order and name of edit item

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -9,7 +9,7 @@ class App extends Component {
     render() {
         return (
             <SnackbarProvider 
-                maxSnack="3" preventDuplicate 
+                maxSnack={3} preventDuplicate 
                 anchorOrigin={{
                     vertical: 'bottom',
                     horizontal: 'right',

--- a/src/components/item/item.jsx
+++ b/src/components/item/item.jsx
@@ -42,7 +42,7 @@ export class Item extends Component {
         if (option === 'Delete from all snapshots') {
             this.props.deleteItem(this.props.item._id)
         }
-        else if (option === 'Rename Item') {
+        else if (option === 'Edit') {
             this.setState({
                 ...this.state,
                 isEdit: true
@@ -78,11 +78,10 @@ export class Item extends Component {
 
     render = () => {
         const { classes } = this.props;
-        console.log(this.props)
 
         const options = [
-            'Delete from all snapshots',
-            'Rename Item'
+            'Edit',
+            'Delete from all snapshots'
         ]
         
         const item = (

--- a/src/containers/itemCollection/itemCollection.jsx
+++ b/src/containers/itemCollection/itemCollection.jsx
@@ -132,12 +132,6 @@ export class ItemCollection extends Component {
             this.props.addItem(item)
         } else {
             // In this case, there is a duplicate, so we send an alert
-            this.setState({
-                isEdit: event !== null, //if user hit enter
-                name: '',
-                _id: '',
-                size: 1,
-            })
             this.props.enqueueSnackbar("Duplicated name: " + item.name)
         }
     }


### PR DESCRIPTION
Fixed misc bugs:
- maxSnack value must not be a string, must be a numeral
- Changed name from Rename Item to Edit, to be consistent with container menu
- fixed bug when saving a duplicate, it resets the state, so when you modify the name and try saving again, it results in an error.