### PR TITLE
Handle clicks on containers the same way we do for items

### DIFF
--- a/src/components/editContainer/editContainer.jsx
+++ b/src/components/editContainer/editContainer.jsx
@@ -36,7 +36,7 @@ export class EditContainer extends Component {
             if (this.props.name === '') {
                 this.inputName.focus()
             } else {
-                this.props.handleEnter(e)
+                this.props.handleEnter(e.key)
             }
         }
     }
@@ -46,7 +46,7 @@ export class EditContainer extends Component {
             return;
         }
         if (this.props.name !== '' && this.props.size !== 0 && this.props.size !== '') {
-            this.props.handleEnter()
+            this.props.handleEnter(null)
         } else if (this.props.name === '' && (this.props.size === '' || this.props.size === 0)) {
             this.props.handleEsc()
         }

--- a/src/containers/containerCollection/containerCollection.jsx
+++ b/src/containers/containerCollection/containerCollection.jsx
@@ -93,7 +93,7 @@ export class ContainerCollection extends Component {
 
             this.props.addContainer(container)
             // If user presses enter, add another container
-            if (event.key === 'Enter') {
+            if (event === 'Enter') {
                 this.setState({
                     isEdit: true,
                     _id: uuid('container'),


### PR DESCRIPTION
Fix a bug where when you click away from a container after filling in all fields, the app crashes. The root cause was the handleEnter function expects an event with a key, and clicking doesn't do that. This issue doesn't appear when interacting with items, so the container handleEnter function was changed to be the same as an item's.