### PR TITLE
fixed error where the unassigned item being rendered was unassigned

### DIFF
--- a/src/containers/itemCollection/itemCollection.jsx
+++ b/src/containers/itemCollection/itemCollection.jsx
@@ -199,17 +199,23 @@ export class ItemCollection extends Component {
                                     <Grid container spacing={0}>
                                         {
                                             this.props.unsnapshot_items.map((id, index) => {
-                                                return (
-                                                    <Grid item xs = {12} key = {id}>
-                                                        <Item 
-                                                            item = {this.props.items.find(ele => ele._id === id)}
-                                                            deleteItem = {this.props.deleteItem} 
-                                                            index={index} 
-                                                            getDragItemColor={this.props.getDragItemColor} 
-                                                            containerId="itemcollection"
-                                                        />
-                                                    </Grid>
-                                                )
+                                                const item = this.props.items.find(ele => ele._id === id)
+                                                // Check for null items
+                                                if (item) {
+                                                    return (
+                                                        <Grid item xs = {12} key = {id}>
+                                                            <Item 
+                                                                item = {item}
+                                                                deleteItem = {this.props.deleteItem} 
+                                                                index={index} 
+                                                                getDragItemColor={this.props.getDragItemColor} 
+                                                                containerId="itemcollection"
+                                                            />
+                                                        </Grid>
+                                                    )
+                                                }
+                                                console.log("attempted to render null item")
+                                                return
                                             })
                                         }
                                         { this.displayEditItem() }

--- a/src/containers/snapshot/snapshot.jsx
+++ b/src/containers/snapshot/snapshot.jsx
@@ -78,19 +78,21 @@ class Snapshot extends Component {
         const snap = this.getSnapshot(snapshotId)
         // make sure no undefined items in unassigned
         let clean_unassigned = snap.unassigned.filter(n => n)
+        // make sure all unassigned items exist
+        clean_unassigned = clean_unassigned.filter(n => this.props.real.items.find(i => i._id == n))
         // make a set of all items
         let unassigned_set = new Set(this.props.real.items.map(item => item._id))
         for (let container of snap.snapshotContainers) {
+            // delete items from unassigned if they are assigned to container
             container.items.map(item => unassigned_set.delete(item))
         }
-
         clean_unassigned.map(item => unassigned_set.delete(item)) // Removed the items that are already in unassigned.
         // Self healing. If there are missing unassigned items, add them back into unassigned.
         if (unassigned_set.size > 0) {
             console.log("there are some missing unassigned")
             Array.from(unassigned_set).map(item => clean_unassigned.push(item))
-            this.props.setUnassignedItems(snapshotId, clean_unassigned)
         }
+        this.props.setUnassignedItems(snapshotId, clean_unassigned)
     }
 
     healSnapshotContainers = (snapshotId) => {


### PR DESCRIPTION
Ryuta found a bug where an unassigned item was created that didn't exist in the items list. Updated the healing method to make sure to remove corrupted items. And also added a check not to render null items.