### PR TITLE
Item cleanup and note rendering performance increase

### DIFF
--- a/src/components/container/container.jsx
+++ b/src/components/container/container.jsx
@@ -194,9 +194,7 @@ export class Container extends Component {
                                                 <Grid item xs={12} key={item._id}>
                                                     <Item 
                                                         item={item} 
-                                                        index={index} 
-                                                        getDragItemColor={this.props.getDragItemColor} 
-                                                        containerId={this.props.container._id} />
+                                                        index={index} />
                                                 </Grid>
                                             )
                                         return {}

--- a/src/components/item/item.jsx
+++ b/src/components/item/item.jsx
@@ -88,9 +88,8 @@ export class Item extends Component {
     }
 
     getNote = () => {
-        const item = this.props.real.items.find(x => x._id === this.props.item._id);
-        if ('notes' in item && item.notes) {
-            return item.notes;
+        if ('notes' in this.props.item && this.props.item.notes) {
+            return this.props.item.notes;
         }
     }
 
@@ -163,8 +162,7 @@ Item.propTypes = {
         name: PropTypes.string,
         size: PropTypes.number
     }),
-    getDragItemColor: PropTypes.func,
-    containerId: PropTypes.string
+    index: PropTypes.number
 }
 
 const mapStateToProps = (state, ownProps) => {

--- a/src/containers/itemCollection/itemCollection.jsx
+++ b/src/containers/itemCollection/itemCollection.jsx
@@ -205,11 +205,8 @@ export class ItemCollection extends Component {
                                                 return (
                                                     <Grid item xs = {12} key = {id}>
                                                         <Item 
-                                                            item = {item}
-                                                            index={index} 
-                                                            getDragItemColor={this.props.getDragItemColor} 
-                                                            containerId="itemcollection"
-                                                        />
+                                                            item={item}
+                                                            index={index} />
                                                     </Grid>
                                                 )
                                             }


### PR DESCRIPTION
Removed the O(n) lookup for item and the note for the item. The item note is already passed into props... duh...

Tested that Item still renders.